### PR TITLE
[Feature] 프로필 화면 및 채팅 시작 로직 구현

### DIFF
--- a/Feelter/Sources/App/AppDelegate.swift
+++ b/Feelter/Sources/App/AppDelegate.swift
@@ -55,12 +55,24 @@ extension AppDelegate {
         
         // Device Token을 FCM에 등록
         Messaging.messaging().apnsToken = deviceToken
+        Messaging.messaging().token { token, error in
+            if let error = error {
+                print("Error fetching FCM registration token: \(error)")
+                return
+            }
+            
+            if let token = token {
+                print("FCM registration token: \(token)")
+            } else {
+                print("FCM registration token is nil")
+            }
+        }
         
         let newToken = deviceToken.reduce("") { $0 + String(format: "%02X", $1) }
         
         let tokenManager = DIContainer.shared.resolve(TokenManager.self)
         
-        // 디바이스 토큰이 저장되있지 않은 경우 (로그인 화면), 저장
+        // 디바이스 토큰이 저장되있지 않은 경우 (로그인 화면인 경우), 새로 저장
         guard let current = tokenManager.deviceToken else {
             tokenManager.updateDeviceToken(newToken)
             return
@@ -69,6 +81,7 @@ extension AppDelegate {
         // 기존 디바이스 토큰과 새로 발급받은 디바이스 토큰이 동일한 경우, 종료
         guard current != newToken else { return }
         
+        // 디바이스 토큰 업데이트
         let networkProvider = DIContainer.shared.resolve(NetworkProvider.self)
         Task {
             do {
@@ -88,6 +101,7 @@ extension AppDelegate {
     }
     
     private func configurePushNotification() {
+        print(#function)
         Messaging.messaging().delegate = self
         let center = UNUserNotificationCenter.current()
         center.delegate = self
@@ -95,14 +109,6 @@ extension AppDelegate {
         // 알림을 표시하기 위한 승인을 요청
         center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
             print("Permission granted: \(granted)")
-        }
-        
-        Messaging.messaging().token { token, error in
-            if let error = error {
-                print("Error fetching FCM registration token: \(error)")
-            } else if let token = token {
-                print("FCM registration token: \(token)")
-            }
         }
     }
 }

--- a/Feelter/Sources/Core/BaseView/BaseViewController.swift
+++ b/Feelter/Sources/Core/BaseView/BaseViewController.swift
@@ -133,3 +133,13 @@ private extension BaseViewController {
         navigationController?.popViewController(animated: true)
     }
 }
+
+extension BaseViewController {
+    func showTabBar() {
+        NotificationCenter.default.post(name: .ShowTabBar, object: nil)
+    }
+    
+    func hideTabBar() {
+        NotificationCenter.default.post(name: .HideTabBar, object: nil)
+    }
+}

--- a/Feelter/Sources/Core/Network/API/UserAPI.swift
+++ b/Feelter/Sources/Core/Network/API/UserAPI.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum UserAPI {
     case todayAuthor
+    case myProfile
 }
 
 extension UserAPI: APIEndpoint {
@@ -20,18 +21,23 @@ extension UserAPI: APIEndpoint {
         switch self {
         case .todayAuthor:
             "/v1/users/today-author"
+        case .myProfile:
+            "/v1/users/me/profile"
         }
     }
     
     var method: HTTPMethod {
         switch self {
         case .todayAuthor: .get
+        case .myProfile: .get
         }
     }
     
     var task: HTTPTask {
         switch self {
         case .todayAuthor:
+                .requestPlain
+        case .myProfile:
                 .requestPlain
         }
     }

--- a/Feelter/Sources/Data/DTO/Chat/Response/ChatRoomDTO.swift
+++ b/Feelter/Sources/Data/DTO/Chat/Response/ChatRoomDTO.swift
@@ -30,7 +30,7 @@ struct ChatRoomResponseDTO: Decodable {
         return .init(
             roomID: roomID,
             participants: participants.map { $0.toDomain() },
-            lastMessage: isLastMessageFile ? "파일을 보냈습니다." : lastChat?.content ?? "",
+            lastMessage: lastChat?.content,
             isLastMessageFile: isLastMessageFile,
             createdAt: UTCDateFormatter.shared.date(from: createdAt) ?? Date(),
             updatedAt: UTCDateFormatter.shared.date(from: updatedAt) ?? Date(),

--- a/Feelter/Sources/Data/DataSource/ChatDataSource.swift
+++ b/Feelter/Sources/Data/DataSource/ChatDataSource.swift
@@ -42,6 +42,7 @@ struct ChatDataSourceImpl: ChatDataSource {
     func fetchChatRooms() -> [ChatRoom] {
         let realm = RealmStorage.shared.realm
         let realmRooms = realm.objects(RealmChatRoom.self)
+            .filter { $0.lastMessage != nil }
         return Array(realmRooms).map { $0.toDomain() }
     }
     

--- a/Feelter/Sources/Data/DataSource/ChatDataSource.swift
+++ b/Feelter/Sources/Data/DataSource/ChatDataSource.swift
@@ -17,6 +17,8 @@ protocol ChatDataSource {
     @MainActor
     func saveChatRooms(_ rooms: [ChatRoom]) throws
     @MainActor
+    func findChatRoom(opponentID: String) -> ChatRoom?
+    @MainActor
     func updateChatRoom(
         roomID: String,
         updatedAt: Date,
@@ -49,6 +51,13 @@ struct ChatDataSourceImpl: ChatDataSource {
             let realmRooms = rooms.map { RealmChatRoom(from: $0) }
             realm.add(realmRooms, update: .modified)
         }
+    }
+    
+    func findChatRoom(opponentID: String) -> ChatRoom? {
+        let realm = RealmStorage.shared.realm
+        let localRoom = realm.objects(RealmChatRoom.self)
+            .first { $0.participants.contains(where: { $0.userID == opponentID }) }
+        return localRoom?.toDomain()
     }
     
     func updateChatRoom(

--- a/Feelter/Sources/Data/DataSource/ChatDataSource.swift
+++ b/Feelter/Sources/Data/DataSource/ChatDataSource.swift
@@ -42,7 +42,11 @@ struct ChatDataSourceImpl: ChatDataSource {
     func fetchChatRooms() -> [ChatRoom] {
         let realm = RealmStorage.shared.realm
         let realmRooms = realm.objects(RealmChatRoom.self)
-            .filter { $0.lastMessage != nil }
+            .where { $0.lastMessage != nil || $0.isLastMessageFile } // 채팅 메시지가 존재하는 채팅방만 가져오기
+            .sorted(by: [
+                .init(keyPath: "localUpdatedAt", ascending: false),
+                .init(keyPath: "updatedAt", ascending: false)
+            ])
         return Array(realmRooms).map { $0.toDomain() }
     }
     
@@ -57,7 +61,8 @@ struct ChatDataSourceImpl: ChatDataSource {
     func findChatRoom(opponentID: String) -> ChatRoom? {
         let realm = RealmStorage.shared.realm
         let localRoom = realm.objects(RealmChatRoom.self)
-            .first { $0.participants.contains(where: { $0.userID == opponentID }) }
+            .where { $0.participants.userID == opponentID }
+            .first
         return localRoom?.toDomain()
     }
     
@@ -98,8 +103,8 @@ struct ChatDataSourceImpl: ChatDataSource {
     func fetchChatMessages(roomID: String) -> [ChatMessage] {
         let realm = RealmStorage.shared.realm
         let realmMessages = realm.objects(RealmChatMessage.self)
-            .filter("roomID == %@", roomID)
-            .sorted(byKeyPath: "createdAt", ascending: true)
+            .where { $0.roomID == roomID }
+            .sorted(by: \.createdAt, ascending: true)
         return Array(realmMessages).map { $0.toDomain() }
     }
     

--- a/Feelter/Sources/Data/Realm/RealmChatRoom.swift
+++ b/Feelter/Sources/Data/Realm/RealmChatRoom.swift
@@ -12,7 +12,7 @@ import RealmSwift
 final class RealmChatRoom: Object {
     @Persisted(primaryKey: true) var roomID: String
     @Persisted var participants: List<RealmMessageSender>
-    @Persisted var lastMessage: String
+    @Persisted var lastMessage: String?
     @Persisted var isLastMessageFile: Bool
     @Persisted var unReadCount: Int
     @Persisted var createdAt: Date
@@ -22,7 +22,7 @@ final class RealmChatRoom: Object {
     convenience init(
         roomID: String,
         participants: List<RealmMessageSender>,
-        lastMessage: String,
+        lastMessage: String?,
         isLastMessageFile: Bool,
         unReadCount: Int = 0,
         createdAt: Date,

--- a/Feelter/Sources/Data/Repository/Implement/ChatRepositoryImpl.swift
+++ b/Feelter/Sources/Data/Repository/Implement/ChatRepositoryImpl.swift
@@ -36,6 +36,11 @@ final class ChatRepositoryImpl: ChatRepository {
     
     // MARK: - 채팅방 관련
     func createRoom(opponentID: String) async throws -> ChatRoom {
+        // 이미 기존에 Realm에 저장된 채팅방이 있을 경우, 서버 통신 없이 반환
+        if let localRoom = await chatDataSource.findChatRoom(opponentID: opponentID) {
+            return localRoom
+        }
+        
         let requestDTO = CreateChatRoomRequestDTO(opponentID: opponentID)
         
         let response = try await networkProvider.request(
@@ -43,7 +48,11 @@ final class ChatRepositoryImpl: ChatRepository {
             type: ChatRoomResponseDTO.self
         )
         
-        return response.toDomain()
+        let chatRoom = response.toDomain()
+        
+        try await chatDataSource.saveChatRooms([chatRoom])
+        
+        return chatRoom
     }
     
     func fetchRooms() async throws -> [ChatRoom] {
@@ -112,6 +121,7 @@ final class ChatRepositoryImpl: ChatRepository {
         
         try await chatDataSource.saveChatMessages(messages)
         
+        // TODO: 서버로부터 특정 날짜 이후에 해당하는 새로운 메시지를 받은 경우 외 아무런 메시지를 받지 않은 경우, 업데이트 날짜만 현재 날짜로 변경하기 (채팅방 입장할 때마다 불필요한 API 호출 방지)
         if let lastChat = messages.last {
             try await chatDataSource.updateChatRoom(
                 roomID: roomID,
@@ -121,6 +131,8 @@ final class ChatRepositoryImpl: ChatRepository {
             )
             
             chatRooms = await chatDataSource.fetchChatRooms()
+        } else {
+            // TODO: 업데이트 날짜만 현재 날짜(파라미터로 전달받은 after)로 변경
         }
             
         return messages
@@ -170,8 +182,11 @@ extension ChatRepositoryImpl {
                 return true
             }
             
+            // TODO: 서버 업데이트 날짜 > 로컬 업데이트 날짜인 경우만 고려해보기
+            // -> 채팅방 입장 후 업데이트 
+            //
             // 채팅방 업데이트 날짜 비교
-            return serverRoom.updatedAt != localRoom.updatedAt
+            return serverRoom.updatedAt > localRoom.updatedAt
         }
     }
     

--- a/Feelter/Sources/Data/Repository/Implement/ChatRepositoryImpl.swift
+++ b/Feelter/Sources/Data/Repository/Implement/ChatRepositoryImpl.swift
@@ -121,7 +121,6 @@ final class ChatRepositoryImpl: ChatRepository {
         
         try await chatDataSource.saveChatMessages(messages)
         
-        // TODO: 서버로부터 특정 날짜 이후에 해당하는 새로운 메시지를 받은 경우 외 아무런 메시지를 받지 않은 경우, 업데이트 날짜만 현재 날짜로 변경하기 (채팅방 입장할 때마다 불필요한 API 호출 방지)
         if let lastChat = messages.last {
             try await chatDataSource.updateChatRoom(
                 roomID: roomID,
@@ -131,8 +130,6 @@ final class ChatRepositoryImpl: ChatRepository {
             )
             
             chatRooms = await chatDataSource.fetchChatRooms()
-        } else {
-            // TODO: 업데이트 날짜만 현재 날짜(파라미터로 전달받은 after)로 변경
         }
             
         return messages
@@ -182,11 +179,8 @@ extension ChatRepositoryImpl {
                 return true
             }
             
-            // TODO: 서버 업데이트 날짜 > 로컬 업데이트 날짜인 경우만 고려해보기
-            // -> 채팅방 입장 후 업데이트 
-            //
             // 채팅방 업데이트 날짜 비교
-            return serverRoom.updatedAt > localRoom.updatedAt
+            return serverRoom.updatedAt != localRoom.updatedAt
         }
     }
     

--- a/Feelter/Sources/Data/Repository/Implement/UserRepositoryImpl.swift
+++ b/Feelter/Sources/Data/Repository/Implement/UserRepositoryImpl.swift
@@ -25,4 +25,13 @@ struct UserRepositoryImpl: UserRepository {
         
         return .init(profile: profile, filters: filters)
     }
+    
+    func fetchMyProfile() async throws -> Profile {
+        let response = try await networkProvider.request(
+            endpoint: UserAPI.myProfile,
+            type: ProfileDTO.self
+        )
+        
+        return response.toDomain()
+    }
 }

--- a/Feelter/Sources/Data/Repository/Interface/UserRepository.swift
+++ b/Feelter/Sources/Data/Repository/Interface/UserRepository.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol UserRepository {
     func fetchTodayAuthor() async throws -> TodayAuthor
+    func fetchMyProfile() async throws -> Profile
 }

--- a/Feelter/Sources/Domain/Entity/Chat/ChatRoom.swift
+++ b/Feelter/Sources/Domain/Entity/Chat/ChatRoom.swift
@@ -11,7 +11,7 @@ struct ChatRoom: Hashable {
     let roomID: String
     let participants: [MessageSender]
     
-    let lastMessage: String
+    let lastMessage: String?
     let isLastMessageFile: Bool
     
     let createdAt: Date

--- a/Feelter/Sources/Feature/Main/Chat/ChatViewController.swift
+++ b/Feelter/Sources/Feature/Main/Chat/ChatViewController.swift
@@ -46,6 +46,18 @@ final class ChatViewController: RxBaseViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        hideTabBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        showTabBar()
+    }
+    
     override func setupView() {
         setupTableView()
     }

--- a/Feelter/Sources/Feature/Main/Chat/ChatViewModel.swift
+++ b/Feelter/Sources/Feature/Main/Chat/ChatViewModel.swift
@@ -57,8 +57,7 @@ final class ChatViewModel: ViewModel {
         input.viewDidLoad
             .do(onNext: { [weak self] _ in
                 guard let self else { return }
-                chatRepository.connectRoom(roomID: self.roomID) { [weak self] message in
-                    guard let self else { return }
+                chatRepository.connectRoom(roomID: self.roomID) { message in
                     receiveMessageTrigger.accept(message)
                 }
             })

--- a/Feelter/Sources/Feature/Main/ChatList/Cell/ChatRoomTableViewCell.swift
+++ b/Feelter/Sources/Feature/Main/ChatList/Cell/ChatRoomTableViewCell.swift
@@ -19,7 +19,7 @@ final class ChatRoomTableViewCell: BaseTableViewCell {
         let profileImageURL: String?
         let name: String
         let message: String
-        let date: String
+        let date: Date
         let unreadCount: Int
     }
 
@@ -140,7 +140,7 @@ final class ChatRoomTableViewCell: BaseTableViewCell {
         
         nameLabel.text = item.name
         messageLabel.text = item.message
-        dateLabel.text = item.date
+        dateLabel.text = item.date.formatted(.basic)
         
         if item.unreadCount > 0 {
             unreadBadgeView.isHidden = false

--- a/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewController.swift
+++ b/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewController.swift
@@ -129,17 +129,17 @@ extension ChatRoomViewController {
                         for: indexPath
                       ) as? ChatRoomTableViewCell else { return .init() }
                 
-                // TODO: 상대방 찾기
                 let userID = viewModel.userID
                 guard let opponent = room.participants.first(where: {
                     $0.userID != userID
                 }) else { return .init() }
+                let message = room.isLastMessageFile ? "파일을 보냈습니다." : room.lastMessage ?? ""
                 
                 cell.configureCell(.init(
                     profileImageURL: opponent.profileImageURL,
                     name: opponent.nickname,
-                    message: room.lastMessage,
-                    date: room.localUpdatedAt.formatted(.basic),
+                    message: message,
+                    date: room.localUpdatedAt,
                     unreadCount: 0
                 ))
                 return cell

--- a/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewController.swift
+++ b/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewController.swift
@@ -152,15 +152,11 @@ extension ChatRoomViewController {
 
 extension ChatRoomViewController {
     private func updateDataSource(with newRooms: [ChatRoom]) {
-        let sortedRooms = newRooms.sorted {
-            ($0.localUpdatedAt, $0.updatedAt) >
-            ($1.localUpdatedAt, $1.updatedAt)
-        }
         
         // 새로운 스냅샷을 직접 생성 (DiffableDataSource가 차이점을 자동 계산)
         var newSnapShot = NSDiffableDataSourceSnapshot<Int, ChatRoom>()
         newSnapShot.appendSections([0])
-        newSnapShot.appendItems(sortedRooms)
+        newSnapShot.appendItems(newRooms)
         
         let isAnimating = dataSource.snapshot().numberOfItems != 0
         

--- a/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewController.swift
+++ b/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewController.swift
@@ -27,6 +27,18 @@ final class ChatRoomViewController: RxBaseViewController {
 
     private let viewModel = ChatRoomViewModel()
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        hideTabBar()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        showTabBar()
+    }
+    
     override func setupView() {
         title = "Chat"
         view.backgroundColor = .gray100

--- a/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewModel.swift
+++ b/Feelter/Sources/Feature/Main/ChatList/ChatRoomViewModel.swift
@@ -48,6 +48,7 @@ final class ChatRoomViewModel: ViewModel {
         
         input.receivedAPNs
             .withAsyncResult(with: self) { owner, payload in
+                // TODO: 로컬에 저장되지 않은 채팅방ID인 경우(새로운 상대방한테 받은 경우), 전체 채팅방 목록 서버로 가져오는 로직 필요
                 try await owner.chatRepository.updateRoom(apnsPayload: payload)
                 
                 let rooms = await owner.chatRepository.fetchLocalRooms()

--- a/Feelter/Sources/Feature/Main/Detail/CollectionView/Cell/AuthorProfileCollectionViewCell.swift
+++ b/Feelter/Sources/Feature/Main/Detail/CollectionView/Cell/AuthorProfileCollectionViewCell.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import RxSwift
 import SnapKit
 
 final class AuthorProfileCollectionViewCell: BaseCollectionViewCell {
@@ -17,14 +18,54 @@ final class AuthorProfileCollectionViewCell: BaseCollectionViewCell {
         let view = ProfileView()
         return view
     }()
+    
+    let chatButton: UIView = {
+        let view = UIView()
+        view.backgroundColor = .deepTurquoise
+        view.layer.cornerRadius = 8
+        return view
+    }()
+
+    private let chatImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        view.image = .message
+        view.tintColor = .gray30
+        return view
+    }()
+    
+    private(set) var disposeBag = DisposeBag()
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        disposeBag = DisposeBag()
+    }
 
     override func setupSubviews() {
-        contentView.addSubview(profileView)
+        contentView.addSubviews([
+            profileView,
+            chatButton
+        ])
+        
+        chatButton.addSubview(chatImageView)
     }
     
     override func setupConstraints() {
         profileView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+            make.leading.verticalEdges.equalToSuperview()
+            make.trailing.equalTo(chatButton.snp.leading).offset(-15)
+        }
+        
+        chatButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview()
+            make.size.equalTo(44)
+            make.centerY.equalToSuperview()
+        }
+        
+        chatImageView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.size.equalTo(32)
         }
     }
     

--- a/Feelter/Sources/Feature/Main/Detail/FilterDetailView.swift
+++ b/Feelter/Sources/Feature/Main/Detail/FilterDetailView.swift
@@ -40,6 +40,7 @@ final class FilterDetailView: RxBaseView {
     private weak var imageSliderCell: ImageSliderCollectionViewCell?
     
     let paymentButtonTapTrigger = PublishRelay<Void>()
+    let chatButtonTapTrigger = PublishRelay<Void>()
     
     override func setupView() {
         setupCollectionView()
@@ -262,6 +263,12 @@ private extension FilterDetailView {
                         phoneNumber: "",
                         hashTags: []
                     ))
+                    
+                    cell.chatButton.rx
+                        .tap
+                        .bind(to: self.chatButtonTapTrigger)
+                        .disposed(by: cell.disposeBag)
+                    
                     return cell
                     
                 case .authorHashTags:

--- a/Feelter/Sources/Feature/Main/Detail/FilterDetailViewController.swift
+++ b/Feelter/Sources/Feature/Main/Detail/FilterDetailViewController.swift
@@ -58,7 +58,9 @@ final class FilterDetailViewController: RxBaseViewController {
                 .asObservable(),
             paymentButtonTapped: mainView.paymentButtonTapTrigger
                 .asObservable(),
-            succeedPayment: succeedPaymentTrigger.asObservable()
+            succeedPayment: succeedPaymentTrigger.asObservable(),
+            chatMessageButtonTapped: mainView.chatButtonTapTrigger
+                .asObservable()
         )
 
         let output = viewModel.transform(input: input)

--- a/Feelter/Sources/Feature/Main/Detail/FilterDetailViewController.swift
+++ b/Feelter/Sources/Feature/Main/Detail/FilterDetailViewController.swift
@@ -94,6 +94,18 @@ final class FilterDetailViewController: RxBaseViewController {
                 owner.present(vc, animated: true)
             }
             .disposed(by: disposeBag)
+        
+        output.receiveChatRoom
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, room in
+                let vm = ChatViewModel(
+                    roomID: room.roomID,
+                    updatedAt: room.updatedAt
+                )
+                let vc = ChatViewController(viewModel: vm)
+                owner.navigationController?.pushViewController(vc, animated: true)
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Feelter/Sources/Feature/Main/Detail/FilterDetailViewModel.swift
+++ b/Feelter/Sources/Feature/Main/Detail/FilterDetailViewModel.swift
@@ -23,10 +23,12 @@ final class FilterDetailViewModel: ViewModel {
         let filterDetail = PublishRelay<FilterDetail>()
         let updatedLikeStatus = PublishRelay<Bool>()
         let receiveOrderCode = PublishRelay<PaymentInfo>()
+        let receiveChatRoom = PublishRelay<ChatRoom>()
     }
     
     @Dependency private var filterRepository: FilterRepository
     @Dependency private var orderRepository: OrderRepository
+    @Dependency private var chatRepository: ChatRepository
     
     private let filterID: String
     private(set) var isLiked: Bool
@@ -116,6 +118,23 @@ final class FilterDetailViewModel: ViewModel {
                 owner.filter = newFilter
                 
                 output.filterDetail.accept(newFilter)
+            }
+            .disposed(by: disposeBag)
+        
+        input.chatMessageButtonTapped
+            .compactMap { [weak self] in
+                self?.filter?.author.userID
+            }
+            .withAsyncResult(with: self) { owner, opponentID in
+                try await owner.chatRepository.createRoom(opponentID: opponentID)
+            }
+            .subscribe(with: self) { owner, result in
+                switch result {
+                case .success(let room):
+                    output.receiveChatRoom.accept(room)
+                case .failure(let error):
+                    print(error)
+                }
             }
             .disposed(by: disposeBag)
         

--- a/Feelter/Sources/Feature/Main/Detail/FilterDetailViewModel.swift
+++ b/Feelter/Sources/Feature/Main/Detail/FilterDetailViewModel.swift
@@ -16,6 +16,7 @@ final class FilterDetailViewModel: ViewModel {
         let likeButtonTapped: Observable<Void>
         let paymentButtonTapped: Observable<Void>
         let succeedPayment: Observable<Void>
+        let chatMessageButtonTapped: Observable<Void>
     }
     
     struct Output {

--- a/Feelter/Sources/Feature/Main/MyPage/CollectionView/MainProfileCollectionViewCell.swift
+++ b/Feelter/Sources/Feature/Main/MyPage/CollectionView/MainProfileCollectionViewCell.swift
@@ -1,0 +1,199 @@
+//
+//  MainProfileCollectionViewCell.swift
+//  Feelter
+//
+//  Created by 이정동 on 8/22/25.
+//
+
+import UIKit
+
+import RxSwift
+import SnapKit
+
+typealias MainProfileCellItem = MainProfileCollectionViewCell.Item
+
+final class MainProfileCollectionViewCell: BaseCollectionViewCell {
+    
+    static let identifier = "MainProfileCollectionViewCell"
+    
+    struct Item: Hashable {
+        let profileImageURL: String
+        let nickname: String
+        let name: String?
+        let email: String
+    }
+    
+    private let profileImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.layer.cornerRadius = 36
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    private let labelStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.alignment = .leading
+        view.spacing = 5
+        return view
+    }()
+
+    private let nicknameLabel: UILabel = {
+        let view = UILabel()
+        view.textColor = .gray30
+        view.font = .hakgyoansimMulgyeol(size: 20, weight: .bold)
+        return view
+    }()
+    
+    private let nameLabel: UILabel = {
+        let view = UILabel()
+        view.textColor = .gray75
+        view.font = .pretendard(size: 14, weight: .medium)
+        return view
+    }()
+    
+    private let emailLabel: UILabel = {
+        let view = UILabel()
+        view.textColor = .gray75
+        view.font = .pretendard(size: 14, weight: .medium)
+        return view
+    }()
+
+    private let horizontalStackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .horizontal
+        view.spacing = 15
+        view.alignment = .fill
+        view.distribution = .fillEqually
+        return view
+    }()
+
+    let editProfileContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .deepTurquoise
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let editProfileLabel: UILabel = {
+        let view = UILabel()
+        view.text = "프로필 편집"
+        view.textColor = .gray30
+        view.font = .pretendard(size: 13, weight: .medium)
+        return view
+    }()
+
+    let chatRoomsContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .deepTurquoise
+        view.layer.cornerRadius = 8
+        return view
+    }()
+    
+    private let chatRoomsLabel: UILabel = {
+        let view = UILabel()
+        view.text = "채팅 목록"
+        view.textColor = .gray30
+        view.font = .pretendard(size: 13, weight: .medium)
+        return view
+    }()
+    
+    private(set) var disposeBag = DisposeBag()
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        disposeBag = DisposeBag()
+    }
+    
+    override func setupSubviews() {
+        contentView.addSubviews([
+            profileImageView,
+            labelStackView,
+            horizontalStackView
+        ])
+        
+        labelStackView.addArrangedSubviews([
+            nicknameLabel,
+            nameLabel,
+            emailLabel
+        ])
+        
+        horizontalStackView.addArrangedSubviews([
+            editProfileContainerView,
+            chatRoomsContainerView
+        ])
+        
+        editProfileContainerView.addSubviews([
+            editProfileLabel
+        ])
+        
+        chatRoomsContainerView.addSubviews([
+            chatRoomsLabel
+        ])
+    }
+    
+    override func setupConstraints() {
+        profileImageView.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+            make.size.equalTo(72)
+        }
+        
+        labelStackView.snp.makeConstraints { make in
+            make.leading.equalTo(profileImageView.snp.trailing).offset(20)
+            make.centerY.equalTo(profileImageView.snp.centerY)
+            make.trailing.equalToSuperview()
+        }
+        
+        horizontalStackView.snp.makeConstraints { make in
+            make.top.equalTo(profileImageView.snp.bottom).offset(25)
+            make.horizontalEdges.equalToSuperview().inset(30)
+            make.height.equalTo(30)
+        }
+        
+        editProfileLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+        
+        chatRoomsLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+    
+    func configureCell(item: MainProfileCellItem) {
+        profileImageView.image = .sample
+        nicknameLabel.text = item.nickname
+        nameLabel.text = item.name
+        emailLabel.text = item.email
+        
+        if let name = item.name, !name.isEmpty {
+            nameLabel.isHidden = false
+        } else {
+            nameLabel.isHidden = true
+        }
+    }
+}
+
+extension MainProfileCollectionViewCell {
+    static func layoutSection() -> NSCollectionLayoutSection {
+        let item = NSCollectionLayoutItem(layoutSize: .init(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .estimated(120)
+        ))
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: .init(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .estimated(120)
+            ),
+            subitems: [item]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        section.contentInsets = .init(top: 20, leading: 20, bottom: 0, trailing: 20)
+        
+        return section
+    }
+}

--- a/Feelter/Sources/Feature/Main/MyPage/MyPageView.swift
+++ b/Feelter/Sources/Feature/Main/MyPage/MyPageView.swift
@@ -1,0 +1,143 @@
+//
+//  MyPageView.swift
+//  Feelter
+//
+//  Created by 이정동 on 8/22/25.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class MyPageView: RxBaseView {
+
+    typealias DataSourceType = UICollectionViewDiffableDataSource<Section, AnyHashable>
+    
+    enum Section: Int {
+        case mainProfile
+    }
+    
+    lazy var collectionView: UICollectionView = {
+        let view = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: UICollectionViewLayout()
+        )
+        view.contentInsetAdjustmentBehavior = .never
+        view.showsVerticalScrollIndicator = false
+        view.backgroundColor = .clear
+        return view
+    }()
+    
+    private var dataSource: DataSourceType!
+    
+    let chatRoomButtonTapTrigger = PublishRelay<Void>()
+    
+    override func setupView() {
+        setupCollectionView()
+    }
+
+    override func setupSubviews() {
+        addSubview(collectionView)
+    }
+    
+    override func setupConstraints() {
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide.snp.top)
+            make.horizontalEdges.bottom.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - Public Method
+
+extension MyPageView {
+    func applyDataSource(profile: Profile) {
+        var snapShot = NSDiffableDataSourceSnapshot<Section, AnyHashable>()
+        
+        snapShot.appendSections([.mainProfile])
+        
+        let mainProfile = MainProfileCellItem(
+            profileImageURL: profile.profileImageURL ?? "",
+            nickname: profile.nickname,
+            name: profile.name,
+            email: profile.email ?? ""
+        )
+        snapShot.appendItems([mainProfile], toSection: .mainProfile)
+        
+        dataSource.apply(snapShot, animatingDifferences: false)
+    }
+}
+
+// MARK: - CollectionView Configuration
+
+extension MyPageView {
+    private func setupCollectionView() {
+        // 1) Compositional Layout 설정
+        configureCompositionalLayout()
+        
+        // 2) 셀 등록
+        registerCollectionViewCells()
+        
+        // 3) DiffableDataSource 설정
+        configureDiffableDataSource()
+    }
+    
+    private func configureCompositionalLayout() {
+        
+        let layout = UICollectionViewCompositionalLayout { sectionIndex, environment in
+            switch Section(rawValue: sectionIndex) {
+            case .mainProfile:
+                return MainProfileCollectionViewCell.layoutSection()
+            default:
+                return MainProfileCollectionViewCell.layoutSection()
+            }
+        }
+        
+        collectionView.collectionViewLayout = layout
+    }
+    
+    private func registerCollectionViewCells() {
+        collectionView.register(
+            MainProfileCollectionViewCell.self,
+            forCellWithReuseIdentifier: MainProfileCollectionViewCell.identifier
+        )
+        
+    }
+    
+    private func configureDiffableDataSource() {
+        dataSource = UICollectionViewDiffableDataSource(
+            collectionView: collectionView,
+            cellProvider: { [weak self] collectionView, indexPath, itemIdentifier in
+                guard let self else { return .init() }
+                
+                switch Section(rawValue: indexPath.section) {
+                case .mainProfile:
+                    guard let item = itemIdentifier as? MainProfileCellItem,
+                          let cell = collectionView.dequeueReusableCell(
+                            withReuseIdentifier: MainProfileCollectionViewCell.identifier,
+                            for: indexPath
+                          ) as? MainProfileCollectionViewCell else {
+                        return .init()
+                    }
+                    
+                    cell.configureCell(item: item)
+                    cell.chatRoomsContainerView.rx
+                        .tap
+                        .bind(to: self.chatRoomButtonTapTrigger)
+                        .disposed(by: cell.disposeBag)
+                    
+                    return cell
+                default:
+                    return .init()
+                }
+            }
+        )
+        
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            
+            return nil
+        }
+    }
+}

--- a/Feelter/Sources/Feature/Main/MyPage/MyPageViewController.swift
+++ b/Feelter/Sources/Feature/Main/MyPage/MyPageViewController.swift
@@ -1,0 +1,47 @@
+//
+//  MyPageViewController.swift
+//  Feelter
+//
+//  Created by 이정동 on 8/22/25.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+final class MyPageViewController: RxBaseViewController {
+
+    private let mainView = MyPageView()
+    
+    private let viewModel = MyPageViewModel()
+    
+    override func loadView() {
+        self.view = mainView
+        
+        title = "Profile"
+    }
+
+    override func bind() {
+        let input = MyPageViewModel.Input(
+            viewDidLoad: .just(())
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        output.myProfile
+            .observe(on: MainScheduler.instance)
+            .subscribe(with: self) { owner, profile in
+                owner.mainView.applyDataSource(profile: profile)
+            }
+            .disposed(by: disposeBag)
+        
+        mainView.chatRoomButtonTapTrigger
+            .subscribe(with: self) { owner, _ in
+                let vc = ChatRoomViewController()
+                owner.navigationController?.pushViewController(vc, animated: true)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/Feelter/Sources/Feature/Main/MyPage/MyPageViewModel.swift
+++ b/Feelter/Sources/Feature/Main/MyPage/MyPageViewModel.swift
@@ -1,0 +1,45 @@
+//
+//  MyPageViewModel.swift
+//  Feelter
+//
+//  Created by 이정동 on 8/22/25.
+//
+
+import Foundation
+
+import RxCocoa
+import RxSwift
+
+final class MyPageViewModel: ViewModel {
+    struct Input {
+        let viewDidLoad: Observable<Void>
+    }
+    
+    struct Output {
+        let myProfile = PublishRelay<Profile>()
+    }
+    
+    @Dependency private var userRepository: UserRepository
+    
+    var disposeBag: DisposeBag = .init()
+    
+    func transform(input: Input) -> Output {
+        let output = Output()
+        
+        input.viewDidLoad
+            .withAsyncResult(with: self) { owner, _ in
+                try await owner.userRepository.fetchMyProfile()
+            }
+            .subscribe(with: self) { owner, result in
+                switch result {
+                case .success(let profile):
+                    output.myProfile.accept(profile)
+                case .failure(let error):
+                    print(error)
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        return output
+    }
+}

--- a/Feelter/Sources/Feature/Main/TabBarViewController.swift
+++ b/Feelter/Sources/Feature/Main/TabBarViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
 import SnapKit
 
 final class TabBarViewController: RxBaseViewController {

--- a/Feelter/Sources/Feature/Main/TabBarViewController.swift
+++ b/Feelter/Sources/Feature/Main/TabBarViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class TabBarViewController: BaseViewController {
+final class TabBarViewController: RxBaseViewController {
     
     // MARK: - UI Components
     private lazy var containerView: UIView = {
@@ -36,7 +36,7 @@ final class TabBarViewController: BaseViewController {
         let vc2 = UINavigationController(rootViewController: FilterFeedViewController())
         let vc3 = UINavigationController(rootViewController: FilterMakeViewController())
         let vc4 = UIViewController()
-        let vc5 = UIViewController()
+        let vc5 = UINavigationController(rootViewController: MyPageViewController())
         
         vc4.view.backgroundColor = .brightTurquoise
         vc5.view.backgroundColor = .deepTurquoise
@@ -61,6 +61,38 @@ final class TabBarViewController: BaseViewController {
             make.horizontalEdges.equalToSuperview().inset(20)
             make.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
+    }
+    
+    override func bind() {
+        NotificationCenter.default.rx
+            .notification(.ShowTabBar)
+            .subscribe(with: self) { owner, _ in
+                
+                UIView.animate(
+                    withDuration: 0.2,
+                    delay: 0.1,
+                    options: .curveEaseIn
+                ) {
+                    owner.tabBarView.alpha = 1.0
+                    owner.tabBarView.transform = .identity
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        NotificationCenter.default.rx
+            .notification(.HideTabBar)
+            .subscribe(with: self) { owner, _ in
+                
+                UIView.animate(
+                    withDuration: 0.2,
+                    delay: 0,
+                    options: .curveEaseOut
+                ) {
+                    owner.tabBarView.alpha = 0.0
+                    owner.tabBarView.transform = CGAffineTransform(translationX: 0, y: 100)
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/Feelter/Sources/Shared/Extensions/Foundation/NotificationName+Ext.swift
+++ b/Feelter/Sources/Shared/Extensions/Foundation/NotificationName+Ext.swift
@@ -12,4 +12,6 @@ extension Notification.Name {
     static let KeyboardWillHide = UIResponder.keyboardWillHideNotification
     static let ReceiveRemotePush = Notification.Name("ReceiveRemotePush")
     static let ReceiveSocketMessage = Notification.Name("ReceiveSocketMessage")
+    static let ShowTabBar = Notification.Name("showTabBar")
+    static let HideTabBar = Notification.Name("hideTabBar")
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #29 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해 주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Profile (My Page) tab with avatar, name, email and quick access to Chat Rooms.
  - Enabled starting a chat from filter detail and author profile via a new chat button.

- Improvements
  - Reused existing local chat rooms to open chats faster (avoids unnecessary network calls).
  - Chat list shows clearer formatted activity times and preserves a file-message placeholder.
  - Tab bar hides on chat screens and returns on exit for a cleaner experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->